### PR TITLE
Aanzet geautomatiseerde testopstelling

### DIFF
--- a/testopstelling/.gitignore
+++ b/testopstelling/.gitignore
@@ -1,0 +1,22 @@
+# .gitignore
+
+# Hidden Vagrant-directory
+.vagrant
+
+# Python development
+.ropeproject
+
+# Backup files (e.g. Vim, Gedit, etc.)
+*~
+
+# Compiled Python
+*.pyc
+
+# BATS installation
+test/bats/
+
+# Vagrant base boxes (you never know when someone puts one in the repository)
+*.box
+
+# Ignore role directories from Ansible Galaxy (user.role notation)
+ansible/roles/*.*

--- a/testopstelling/README.md
+++ b/testopstelling/README.md
@@ -1,0 +1,38 @@
+# Gebruik Vagrant-omgeving testopstelling
+
+### HOWTO
+
+De gedefinieerde VMs bekijken:
+
+```
+$ vagrant status
+Current machine states:
+
+srvapache                 not created (virtualbox)
+srvcaddy                  not created (virtualbox)
+
+This environment represents multiple VMs. The VMs are all listed
+above with their current state. For more information about a specific
+VM, run `vagrant status NAME`.
+```
+
+Eén van de VMs opstarten en er op inloggen:
+
+```
+$ vagrant up srvapache
+$ vagrant ssh srvapache
+```
+
+Wanneer een VM voor de eerste keer aangemaakt en opgestart wordt, zal een script uitgevoerd worden dat in de subdirectory `provision/` staat en dezelfde naam heeft als de VM (in dit geval `provision/srvapache.sh`. Dit script kan je aanvullen naargelang je eigen noden. Telkens je het script aanpast, voer je dit commando uit:
+
+```
+$ vagrant provision srvapache
+```
+
+In het script wordt al Apache geïnstalleerd en opgestart. Als de VM correct boot, kan je surfen naar <http://192.168.56.51/> en moet je de standaardpagina van Apache zien.
+
+### Vagrantfile
+
+Het bestand Vagrantfile bevat de definitie van de VM's. Bovenaan wordt een array van hashes gedefinieerd met de instellingen van elke individuele VM (`hosts`). In dit geval is dat enkel hostnaam en IP-adres. Verderop volgt er een lus waar door `hosts` gelopen wordt en voor elk item wordt er een VM opgezet met de opgegeven hostnaam en IP adres. De laatste lijn in de lus zorgt er voor dat een script voor de configuratie van de VM uitgevoerd wordt.
+
+Je kan nieuwe VM's toevoegen door `hosts` uit te breiden en een installatiescript te voorzien in `provision/`. Indien nodig kan je de instellingen van je VMs aanpassen, daarvoor bekijk je best de documentatie van Vagrant.

--- a/testopstelling/Vagrantfile
+++ b/testopstelling/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+hosts = [
+  { name: 'srvapache', ip: '192.168.56.51' },
+  { name: 'srvcaddy',  ip: '192.168.56.52' }
+]
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "geerlingguy/ubuntu1604"
+
+  hosts.each do |host|
+    config.vm.define host[:name] do |node|
+      node.vm.hostname = host[:name]
+      node.vm.network :private_network, ip: host[:ip]
+
+      config.vm.provision 'shell', path: 'provision/' +  host[:name] + '.sh'
+    end
+  end
+end

--- a/testopstelling/provision/srvapache.sh
+++ b/testopstelling/provision/srvapache.sh
@@ -1,0 +1,56 @@
+#! /bin/bash
+#
+#
+
+#{{{ Bash settings
+# abort on nonzero exitstatus
+set -o errexit
+# abort on unbound variable
+set -o nounset
+# don't hide errors within pipes
+set -o pipefail
+#}}}
+#{{{ Variables
+
+# Color definitions
+readonly reset='\e[0m'
+readonly black='\e[0;30m'
+readonly red='\e[0;31m'
+readonly green='\e[0;32m'
+readonly yellow='\e[0;33m'
+readonly blue='\e[0;34m'
+readonly purple='\e[0;35m'
+readonly cyan='\e[0;36m'
+readonly white='\e[0;37m'
+
+#}}}
+
+#{{{ Helper functions
+
+# Usage: error [ARG]...
+#
+# Prints all arguments on the standard error stream
+error() {
+  printf "${red}!!! %s${reset}\n" "${*}" 1>&2
+}
+
+# Usage: info [ARG]...
+#
+# Prints all arguments on the standard output stream
+info() {
+  printf "${yellow}### %s${reset}\n" "${*}"
+}
+#}}}
+
+# Script proper
+
+info "Package installation"
+
+apt-get update
+apt-get -y install apache2
+
+info "Start Apache and enable at boot"
+
+systemctl start apache2.service
+systemctl enable apache2.service
+

--- a/testopstelling/provision/srvcaddy.sh
+++ b/testopstelling/provision/srvcaddy.sh
@@ -1,0 +1,47 @@
+#! /bin/bash
+#
+#
+
+#{{{ Bash settings
+# abort on nonzero exitstatus
+set -o errexit
+# abort on unbound variable
+set -o nounset
+# don't hide errors within pipes
+set -o pipefail
+#}}}
+#{{{ Variables
+
+# Color definitions
+readonly reset='\e[0m'
+readonly black='\e[0;30m'
+readonly red='\e[0;31m'
+readonly green='\e[0;32m'
+readonly yellow='\e[0;33m'
+readonly blue='\e[0;34m'
+readonly purple='\e[0;35m'
+readonly cyan='\e[0;36m'
+readonly white='\e[0;37m'
+
+#}}}
+
+#{{{ Helper functions
+
+# Usage: error [ARG]...
+#
+# Prints all arguments on the standard error stream
+error() {
+  printf "${red}!!! %s${reset}\n" "${*}" 1>&2
+}
+
+# Usage: info [ARG]...
+#
+# Prints all arguments on the standard output stream
+info() {
+  printf "${yellow}### %s${reset}\n" "${*}"
+}
+#}}}
+
+# Script proper
+
+apt-get update


### PR DESCRIPTION
Dag Anton,

hier vind je een aanzet voor een geautomatiseerde testopstelling. Ik heb een Vagrant omgeving opgezet met (op dit moment) 2 VMs, elk gebaseerd op Ubuntu 16.04. Op de ene wordt, als voorbeeld, na booten Apache geïnstalleerd en opgestart.

Let op: als je op Windows werkt gaat dit misschien niet meteen werken. Windows en Linux gebruiken verschillende soorten regeleindes voor tekstbestanden. Het standaardgedrag van Git is om de regeleindes van het eigen systeem te gebruiken (in dat geval dus DOS-regeleindes). Bij het uitvoeren van de installatiescripts op de Linux-VMs loopt het dan fout, want die weigeren bestanden met DOS-regeleindes uit te voeren.

De oplossing is om je lokale kopie van deze repository te verwijderen en opnieuw te klonen, maar deze keer met een extra optie:

```
git clone --config core.autocrlf=input git@github.com:antonRooseleer/Bachelorproef_Anton_Rooseleer.git
```

Als je SourceTree gebruikt, dan zal dit niet werken, het klonen moet vanaf de command-line gebeuren. Hiermee worden de oorspronkelijke regeleindes gerespecteerd en zou het uitvoeren van de installatiescripts moeten werken.

Succes er mee en als er iets niet werkt, laat maar weten.

Mvg,
bert